### PR TITLE
Fix issue with multiple device tokens

### DIFF
--- a/src/notification_manager/notification_manager.rs
+++ b/src/notification_manager/notification_manager.rs
@@ -307,6 +307,15 @@ impl NotificationManager {
         }
     }
     
+    async fn is_pubkey_token_pair_registered(
+        &self,
+        pubkey: &PublicKey,
+        device_token: &str,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let current_device_tokens = self.get_user_device_tokens(pubkey).await?;
+        Ok(current_device_tokens.contains(&device_token.to_string()))
+    }
+    
     async fn is_pubkey_registered(
         &self,
         pubkey: &PublicKey,
@@ -421,7 +430,7 @@ impl NotificationManager {
         pubkey: nostr::PublicKey,
         device_token: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        if self.is_pubkey_registered(&pubkey).await? {
+        if self.is_pubkey_token_pair_registered(&pubkey, &device_token).await? {
             return Ok(());
         }
         self.save_user_device_info(pubkey, device_token).await


### PR DESCRIPTION
Testing
-------

Device: iPhone 15 simulator
iOS: 17.5
Damus: 1.10 (8) 3902fe7b30f38ec104c13087948799e38e26fa91 (Local build) notepush: This commit
Setup:
1. Open app in two separate simulator devices under the same nostr account
2. On both, setup the environment to be local, pointing to the same local notepush Steps:
1. Go to notification settings and try to set notification mode to "push" on both devices
2. Ensure both can be set to push without displaying an error
3. Ensure preferences can be changed without displaying an error
4. When changing one setting, on both devices go back and forth on the notification setting screen and ensure both are independent
5. Send some notifications to this account. Ensure both get the notification
6. Disable DM notifications on one device and send a DM. Ensure only one device gets the notification
7. Try step 6 again, but with likes (and disabling it on the other device)

Results: PASS
- Can register with both devices
- Both devices get new push notifications
- Settings are independent and get respected on each device.


Closes: https://github.com/damus-io/damus/issues/2434